### PR TITLE
Update max timeout setting for languagetool

### DIFF
--- a/container_confs/etc/LTHTTPServer.properties
+++ b/container_confs/etc/LTHTTPServer.properties
@@ -1,1 +1,1 @@
-maxCheckTimeMillis = 30000
+maxCheckTimeMillis = 60000

--- a/container_confs/etc/LTHTTPServer.properties
+++ b/container_confs/etc/LTHTTPServer.properties
@@ -1,1 +1,1 @@
-maxCheckTimeMillis = 70000
+maxCheckTimeMillis = 60000

--- a/container_confs/etc/LTHTTPServer.properties
+++ b/container_confs/etc/LTHTTPServer.properties
@@ -1,1 +1,1 @@
-maxCheckTimeMillis = 60000
+maxCheckTimeMillis = 70000


### PR DESCRIPTION
At the moment, sometimes the languagetool dies down randomly after it takes more than 30 seconds to process a document. The funny thing is, sometimes the same document is processed without a glitch. We suspect that the languagetool takes more time for some documents when it is under extra load by multiple requests at around the same time. We want to try and increase the max timeout setting to see how it behaves. At the moment, this is the only change that makes sense (small enough, easy to try).

See this for more details: https://jira.cheggnet.com/browse/WTB-26